### PR TITLE
Prevent overflow

### DIFF
--- a/whetcwithdraw.sol
+++ b/whetcwithdraw.sol
@@ -211,6 +211,8 @@ contract WhitehatWithdraw is Owned {
     /// deemed as the best choice for the DAO Token holders.
     function extendClosingTime(uint _additionalSeconds) noEther onlyOwner {
         closingTime += _additionalSeconds;
+        if (closingTime<_additionalSeconds) // Prevent overflow.
+            throw;
     }
 
     function () { //no donations


### PR DESCRIPTION
Fix the following vulnerability:
The owner can set a high value of _additionalSeconds in extendClosingTime which will make closingTime overflow.
This can be used to set a closing time in the past, allowing the Owner to withdraw the funds at any time.